### PR TITLE
Fix hexaRole typo

### DIFF
--- a/src/Models/HexaAdmin.php
+++ b/src/Models/HexaAdmin.php
@@ -72,7 +72,7 @@ class HexaAdmin extends Authenticatable implements HasAvatar, FilamentUser
 
     public function roles()
     {
-        return $this->belongsToMany(hexaRole::class, 'hexa_role_admin', 'hexa_admin_id', 'hexa_role_id');
+        return $this->belongsToMany(HexaRole::class, 'hexa_role_admin', 'hexa_admin_id', 'hexa_role_id');
     }
 
     public function canAccessPanel(Panel $panel): bool

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -16,7 +16,7 @@ use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Hexters\HexaLite\Forms\Components\Permission;
-use Hexters\HexaLite\Models\hexaRole;
+use Hexters\HexaLite\Models\HexaRole;
 use Hexters\HexaLite\Traits\HexAccess;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION

This PR fixes a typo where `hexaRole` should be `HexaRole` in the following files:
- `HexaAdmin.php` 
-  `RoleResource.php`