### PR TITLE
Docs: Update authorization examples for Filament v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,40 @@ Users with no assigned role are treated as **Superusers** and have full access b
 To restrict access to a resource:
 
 ```php
-public static function canAccess(): bool
-{
-    return hexa()->can('user.index');
-}
+    public static function getViewAnyAuthorizationResponse(): Response
+    {
+        return hexa()->can('user.index')
+            ? Response::allow()
+            : Response::deny();
+    }
+
+    public static function getCreateAuthorizationResponse(): Response
+    {
+        return hexa()->can('user.create')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to create user.'));
+    }
+
+    public static function getEditAuthorizationResponse(Model $record): Response
+    {
+        return hexa()->can('user.update')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to edit this.'));
+    }
+
+    public static function getDeleteAuthorizationResponse(Model $record): Response
+    {
+        return hexa()->can('user.delete')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to delete user.'));
+    }
+
+    public static function getDeleteAnyAuthorizationResponse(): Response
+    {
+        return hexa()->can('user.delete')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to delete users.'));
+    }
 ```
 
 

--- a/docs/README.V3.md
+++ b/docs/README.V3.md
@@ -134,10 +134,40 @@ Users with no assigned role are treated as **Superusers** and have full access b
 To restrict access to a resource:
 
 ```php
-public static function canAccess(): bool
-{
-    return hexa()->can('user.index');
-}
+    public static function getViewAnyAuthorizationResponse(): Response
+    {
+        return hexa()->can('user.index')
+            ? Response::allow()
+            : Response::deny();
+    }
+
+    public static function getCreateAuthorizationResponse(): Response
+    {
+        return hexa()->can('user.create')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to create user.'));
+    }
+
+    public static function getEditAuthorizationResponse(Model $record): Response
+    {
+        return hexa()->can('user.update')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to edit this.'));
+    }
+
+    public static function getDeleteAuthorizationResponse(Model $record): Response
+    {
+        return hexa()->can('user.delete')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to delete user.'));
+    }
+
+    public static function getDeleteAnyAuthorizationResponse(): Response
+    {
+        return hexa()->can('user.delete')
+            ? Response::allow()
+            : Response::deny(__('You do not have permission to delete users.'));
+    }
 ```
 
 


### PR DESCRIPTION
The current documentation for resource authorization shows an example using the canAccess() method. In Filament v4, the can*() methods are not always reliably called, which can cause issues where permissions (especially for delete actions) do not work as expected.

This PR updates the examples in README.md and docs/README.V3.md to use the modern get...AuthorizationResponse() methods.

    
  reference: [Overriding the can*() authorization methods on a Resource, RelationManager or ManageRelatedRecords class](https://filamentphp.com/docs/4.x/upgrade-guide#low-impact-changes)
 