### PR TITLE
feat: Add support for publishing Config, Views, and Migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Run the database migration:
 ```bash
 php artisan migrate
 ```
+(Optional) Publish configuration, migration, and views:
+If you want to customize the configuration, migration, or views, you can publish them:
+
+```bash
+php artisan vendor:publish --tag=hexa-config
+php artisan vendor:publish --tag=hexa-migrations
+php artisan vendor:publish --tag=hexa-views
+```
 
 Register the plugin in your Filament panel:
 

--- a/src/HexaLiteServiceProvider.php
+++ b/src/HexaLiteServiceProvider.php
@@ -32,7 +32,7 @@ class HexaLiteServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/../config/hexa.php' => config_path('hexa.php'),
-        ]);
+        ], 'hexa-config');
     }
 
     protected function registerView()
@@ -41,6 +41,10 @@ class HexaLiteServiceProvider extends ServiceProvider
             __DIR__ . '/../resources/views',
             'hexa'
         );
+
+        $this->publishes([
+            __DIR__ . '/../resources/views' => resource_path('views/vendor/hexa'),
+        ], 'hexa-views');
     }
 
     protected function registerMigration()
@@ -48,5 +52,9 @@ class HexaLiteServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(
             __DIR__ . '/../database/migrations',
         );
+
+        $this->publishes([
+            __DIR__ . '/../database/migrations' => database_path('migrations'),
+        ], 'hexa-migrations');
     }
 }


### PR DESCRIPTION
## Description
This PR adds the ability for developers to publish the package's **configuration**, **views**, and **migrations** to their local application structure.

## Motivation
Currently, users cannot easily override the default views or configuration settings because the `publishes` method was missing or untagged in the `HexaLiteServiceProvider`. This update allows developers to customize the package (e.g., changing view layouts or modifying config defaults) using standard Laravel artisan commands.

## Changes
- Updated `HexaLiteServiceProvider.php`:
    - Added `publishes()` for config with tag: `--tag=hexa-config`
    - Added `publishes()` for views with tag: `--tag=hexa-views`
    - Added `publishes()` for migrations with tag: `--tag=hexa-migrations`
- Updated `README.md` (and docs) to include instructions on how to publish these assets.

## How to Test
1. Install the package from this branch.
2. Run `php artisan vendor:publish`.
3. Verify that `hexa-config`, `hexa-views`, and `hexa-migrations` tags appear in the list.
4. Run `php artisan vendor:publish --tag=hexa-config` and verify `config/hexa.php` is created.